### PR TITLE
Confirm service confirmation page content

### DIFF
--- a/app/views/prototype-oct2-2017/certificate/submitted.html
+++ b/app/views/prototype-oct2-2017/certificate/submitted.html
@@ -9,7 +9,7 @@
 <br>
 
 <p>
-  We've sent a confirmation email to {%if data['username'] %}{{ data['username'] }}{%else%}yourname@example.com{%endif%}.
+  We've sent a confirmation email to {%if data['username'] %}{{ data['username'] }}{%else%}yourname@example.com{%endif%}
 
   <h2 class="bold-medium">Download certificates of service</h1>
 


### PR DESCRIPTION
Removed a full stop from the end of the email address in the line below the box.

Resolves # . (This is applicable only if this pull request relates to a GitHub issue, delete the line otherwise)

Notes:
*
*
*
